### PR TITLE
Fix/support utf 8 chars

### DIFF
--- a/@types/chunk/index.d.ts
+++ b/@types/chunk/index.d.ts
@@ -1,2 +1,0 @@
-export default function chunk<T>(collection: T[], size: number): T[];
-export default function chunk(collection: string, size: number): string[];

--- a/src/AzureBlobTransport.ts
+++ b/src/AzureBlobTransport.ts
@@ -312,7 +312,8 @@ export class AzureBlobTransport extends TransportStream {
             this.debug(`logging ${tasks.length} line${tasks.length > 1 ? "s" : ""}`);
             const lines = tasks.reduce((pv, v) => pv + v.line + "\n", "");
             // The cast is because the typescript typings are wrong
-            const blockSize = (azure.Constants.BlobConstants as any).MAX_APPEND_BLOB_BLOCK_SIZE;
+            // UTF-8 chars can be 4 bytes so divide by 4
+            const blockSize = (azure.Constants.BlobConstants as any).MAX_APPEND_BLOB_BLOCK_SIZE / 4;
             const blocks = this.chunk(lines, blockSize);
             const blobName = this.getBlobName();
 

--- a/src/AzureBlobTransport.ts
+++ b/src/AzureBlobTransport.ts
@@ -1,6 +1,5 @@
 import async, { AsyncCargo } from "async";
 import azure, { ServiceResponse, StorageError } from "azure-storage";
-import chunk from "chunk";
 import { TransformableInfo } from "logform";
 import { MESSAGE } from "triple-beam";
 import TransportStream from "winston-transport";
@@ -314,7 +313,7 @@ export class AzureBlobTransport extends TransportStream {
             const lines = tasks.reduce((pv, v) => pv + v.line + "\n", "");
             // The cast is because the typescript typings are wrong
             const blockSize = (azure.Constants.BlobConstants as any).MAX_APPEND_BLOB_BLOCK_SIZE;
-            const blocks = chunk(lines, blockSize);
+            const blocks = this.chunk(lines, blockSize);
             const blobName = this.getBlobName();
 
             const completeTasks = (err: Error) => {
@@ -332,4 +331,13 @@ export class AzureBlobTransport extends TransportStream {
             async.eachSeries(blocks, writeBlock, completeTasks);
         });
     }
+
+    private chunk(str: string, size: number) {
+        const numChunks = Math.ceil(str.length / size);
+        const chunks = new Array(numChunks);
+        for (let i = 0, o = 0; i < numChunks; ++i, o += size) {
+          chunks[i] = str.substr(o, size);
+        }
+        return chunks;
+      }
 }


### PR DESCRIPTION
This PR fixes #7 by limiting the single-sent log line length to `MAX_APPEND_BLOB_BLOCK_SIZE / 4`.

It also fixes #3 by providing its own `chunk` implementation and removing an excess dependency.